### PR TITLE
Add in dots and score, refactor Pacman Class

### DIFF
--- a/Game/Cell.js
+++ b/Game/Cell.js
@@ -2,16 +2,19 @@ class Cell {
   constructor(x, y, wall) {
     this.x = x
     this.y = y
-    this.wall = wall 
+    this.wall = wall
+    this.dot = !wall
   }
 
   show() {
-    if (this.wall){
-    fill(0)
-  } else {
-    fill(255)
-  }
-    square(this.x, this.y, scale)
-   
+    if (this.wall) {
+      fill(0)
+      square(this.x, this.y, scale)
+      return
+    } else if (this.dot) {
+      fill(0, 255, 0)
+      circle(this.x + scale / 2, this.y + scale / 2, scale / 2)
+      return
+    }
   }
 }

--- a/Game/Pacman.js
+++ b/Game/Pacman.js
@@ -1,14 +1,24 @@
 class Pacman {
   constructor() {
     this.size = 25
-    //start at grid[11][19]
+    //pacmans actual x and y
     this.x = 12 * this.size
     this.y = 19 * this.size
+    //pacmans position within the grid
     this.i = this.x / this.size
     this.j = this.y / this.size
+    //how many pixels pacman moves per frame. kept at a number evenly
+    //divisible by 25
     this.speed = 2.5
     this.dir = 'left'
     this.nextDir = undefined
+
+    // vars used to keep track of pacmans surroundings
+    // modulus is used to wrap pacman around the board without causing errors
+    this.above = Grid[this.i][(this.j - 1 + rows) % rows]
+    this.below = Grid[this.i][(this.j + 1 + rows) % rows]
+    this.toRight = Grid[(this.i + 1 + cols) % cols][this.j]
+    this.toLeft = Grid[(this.i - 1 + cols) % cols][this.j]
   }
   // draw pacman as a square for now
   show() {
@@ -16,139 +26,99 @@ class Pacman {
     square(this.x, this.y, this.size)
   }
 
-  //notWall boolean function, returns true if directly in front of the
-  //direction given or pacmans current direction is not a wall
-  notWall(dir) {
-    //TODO: see if we can get rid of the math.floor crap
-
-    // grid coordinates for pacmans current position
-    let i = this.x / this.size
-    let j = this.y / this.size
-
+  //notWall boolean function, returns true if directly in front pacmans current direction is not a wall
+  notWall() {
+    const { above, below, toLeft, toRight, dir } = this
     //initialize wall to false, change to true if needed
     let notWall = true
     // direction is doing to be what direction we check, either
-    // this.dir or the parameter
-    let direction = dir || this.dir
-    //check the cell in front of pacman, or the cell in front of pacman if he were to change directions using i,j
 
-    // ex: if direction is up and the cell above pacman is a wall, wall = true
-    if (direction === 'up' && Grid[Math.ceil(i)][Math.ceil(j - 1)].wall) {
-      // while loop used in order to force pacman to land evenly on the grid
-      while (Math.floor(this.y % 25 !== 0)) {
-        this.y++
-      }
+    //check the cell in front of pacman, or the cell in front of pacman if he were to change directions using i,j
+    if (dir === 'up' && above.wall) {
       notWall = false
-    } else if (
-      direction === 'down' &&
-      Grid[Math.floor(i)][Math.floor(j + 1)].wall
-    ) {
-      while (Math.ceil(this.y % 25 !== 0)) {
-        this.y--
-      }
+    } else if (dir === 'down' && below.wall) {
       notWall = false
-    } else if (
-      direction === 'left' &&
-      Grid[Math.ceil(i - 1)][Math.ceil(j)].wall
-    ) {
-      while (Math.floor(this.x % 25 !== 0)) {
-        this.x++
-      }
+    } else if (dir === 'left' && toLeft.wall) {
       notWall = false
-    } else if (
-      direction === 'right' &&
-      Grid[Math.floor(i + 1)][Math.floor(j)].wall
-    ) {
-      while (Math.ceil(this.x % 25 !== 0)) {
-        this.x--
-      }
+    } else if (dir === 'right' && toRight.wall) {
       notWall = false
     }
     return notWall
   }
 
   canChangeDir() {
-    const { dir, nextDir, i, j } = this
+    const { above, below, toLeft, toRight } = this
+    const { dir, nextDir, x, y } = this
     let canMove = false
-
+    // we used modulus of 25 here to only ever allow pacman to change directions
+    // when he is perfectly on a 'grid' square
     if (dir === 'left' || dir === 'right') {
-      if (nextDir === 'up' && !Grid[i][j - 1].wall && this.x % 25 === 0) {
+      if (nextDir === 'up' && !above.wall && x % 25 === 0) {
         canMove = true
-      } else if (nextDir === 'down' && !Grid[i][j + 1].wall && this.x % 25 === 0) {
+      } else if (nextDir === 'down' && !below.wall && x % 25 === 0) {
         canMove = true
-      } else if (nextDir === 'right' && !Grid[i + 1][j].wall) {
+      } else if (nextDir === 'right' && !toRight.wall) {
         canMove = true
-      } else if (nextDir === 'left' && !Grid[i - 1][j].wall) {
+      } else if (nextDir === 'left' && !toLeft.wall) {
         canMove = true
       }
     } else if (dir === 'up' || dir === 'down') {
-      if (nextDir === 'left' && !Grid[i - 1][j].wall && this.y % 25 === 0) {
+      if (nextDir === 'left' && !toLeft.wall && y % 25 === 0) {
         canMove = true
-      } else if (
-        nextDir === 'right' &&
-        !Grid[i + 1][j].wall &&
-        this.y % 25 === 0
-      ) {
+      } else if (nextDir === 'right' && !toRight.wall && y % 25 === 0) {
         canMove = true
-      } else if (nextDir === 'up' && !Grid[i][j - 1].wall) {
+      } else if (nextDir === 'up' && !above.wall) {
         canMove = true
-      } else if (nextDir === 'down' && !Grid[i][j + 1].wall) {
+      } else if (nextDir === 'down' && !below.wall) {
         canMove = true
       }
     }
     return canMove
   }
 
-  // figure out proper i/j once fully passed into the cell
-  // if pacman is moving left && up key is pressed
-  // check spaces directly above to see if a wall or not
-  // if a wall, move another space to the left
-  // this.dir === up
-  // this.nextdir === undefined
-
   tryToChangeDir() {
     // if next dir is up, and up is notWall(), change dir to next dir
     //otherwise do nothing
     if (this.nextDir && this.canChangeDir()) {
-      console.log('we changed dir')
       this.dir = this.nextDir
       this.nextDir = undefined
     }
   }
-  // this moves pacman as long
+  // this moves pacman as long as directly in front of him is not a wall
   move() {
-    // if this.y == center of board && this.x is one pixel over the right edge, just reset it to the left edge, and vise versa
-    // console.log('i: ' + this.i, 'j: ' + this.j)
-
-    if (this.dir === 'left' && this.notWall()) {
-      this.x -= this.speed
+    const { speed, size, dir } = this
+    if (dir === 'left' && this.notWall()) {
+      this.x -= speed
       if (this.x % 25 === 0) {
-        this.i = this.x / this.size
+        //same modulus logic here to allow wrapping when using portals
+          this.i = ((this.x / size)+ cols) % cols
       }
-    } else if (this.dir === 'right' && this.notWall()) {
-      this.x += this.speed
+    } else if (dir === 'right' && this.notWall()) {
+      this.x += speed
       if (this.x % 25 === 0) {
-        this.i = this.x / this.size
+          this.i = ((this.x / size)+ cols ) % cols
       }
-    } else if (this.dir === 'up' && this.notWall()) {
-      this.y -= this.speed
+    } else if (dir === 'up' && this.notWall()) {
+      this.y -= speed
       if (this.y % 25 === 0) {
-        this.j = this.y / this.size
+        this.j = ((this.y / size) + rows ) % rows
       }
-    } else if (this.dir === 'down' && this.notWall()) {
-      this.y += this.speed
+    } else if (dir === 'down' && this.notWall()) {
+      this.y += speed
       if (this.y % 25 === 0) {
-        this.j = this.y / this.size
+        this.j = ((this.y / size)+ rows) % rows
       }
     }
+    this.above = Grid[this.i][(this.j - 1 + rows) % rows]
+    this.below = Grid[this.i][(this.j + 1 + rows) % rows]
+    this.toRight = Grid[(this.i + 1 + cols) % cols][this.j]
+    this.toLeft = Grid[(this.i - 1 + cols) % cols][this.j]
   }
   // function used to change the next direction of pacman
   changeDir(event) {
     event.preventDefault()
     if (keyCode === UP_ARROW) {
-      // console.log('up')
       this.nextDir = 'up'
-      // findNextSpot()
     } else if (keyCode === DOWN_ARROW) {
       this.nextDir = 'down'
     } else if (keyCode === RIGHT_ARROW) {
@@ -159,10 +129,19 @@ class Pacman {
   }
 
   portal() {
-    if (this.dir === 'left' && this.x < 1 ){
-      this.x = width - this.size
-    } else if (this.dir === 'right' && this.x + this.size > width -1) {
-        this.x = this.size
-      }
+    if (this.dir === 'left' && this.x < - this.size ) {
+      this.x = width 
+     
+    } else if (this.dir === 'right' && this.x  > width) {
+      this.x = -this.size
+      
+    }
+  }
+
+  eat() {
+    if (Grid[this.i][this.j].dot) {
+      Grid[this.i][this.j].dot = false
+      score += 10
+    }
   }
 }

--- a/sketch.js
+++ b/sketch.js
@@ -1,4 +1,4 @@
-
+let score = 0
 let pacman
 const cols = 23
 const rows = 27
@@ -13,7 +13,7 @@ pacman.changeDir(event)
 // setup is run once on startup and is generally used to "set up" the canvas and any other necessary initial functions
 function setup() {
   createCanvas(575, 675)
-  pacman = new Pacman()
+  
   
   for (i = 0; i < Grid.length; i++){
   Grid[i] = new Array(rows)
@@ -24,6 +24,7 @@ function setup() {
     Grid[i][j] = new Cell (i*scale, j*scale, LevelOne[i][j])
   }
   }
+  pacman = new Pacman()
 }
 
 // draw is run on a continuous loop at a max frames per second of 60, and is generally used to create visuals within the canvas
@@ -34,4 +35,7 @@ function draw() {
   pacman.tryToChangeDir()
   pacman.portal()
   pacman.move()
+  pacman.eat()
+  fill(255)
+  text(`Score: ${score}`, 10,10)
 }


### PR DESCRIPTION
- Move creation of new Pacman to end of sketch so it has access to
  level variables
- Add score text to 'draw' function
- Add boolean to 'Cell' class that keeps track of whether it is a 'dot'
- Need to map it out or find better logic, for now it is defaulted
  to simply be the opposite of whether it is a wall
- Clean up comments on Pacman Class
- Add 'above, below, toRight, and toLeft' vars to Pacman
  - They are meant to keep track of what is surrounding him, and
    are updated in the 'move ' function.
- Add modulus logic to stop bugs when using portal
- Destructure variables where desirable
- Remove Math.floor() and ceil() functions in notWall() as no longer needed
- Add 'eat' function to Pacman to allow him to eat dots and add to his score